### PR TITLE
Raise explicit warning when no guarantee is found

### DIFF
--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -315,8 +315,8 @@ class PEP(object):
 
         # Raise explicit error when wc_value in infinite
         if wc_value == np.inf:
-            raise UserWarning("PEPit doesn't found any guarantee. "
-                              "The solution to the underlying SDP is infinite!")
+            raise UserWarning("PEPit didn't find any nontrivial worst-case guarantee. "
+                              "It seems that the optimal value of your problem is unbounded.")
 
         # Perform a dimension reduction if required
         if dimension_reduction:

--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -313,6 +313,11 @@ class PEP(object):
         # Store the obtaine value
         wc_value = prob.value
 
+        # Raise explicit error when wc_value in infinite
+        if wc_value == np.inf:
+            raise UserWarning("PEPit doesn't found any guarantee. "
+                              "The solution to the underlying SDP is infinite!")
+
         # Perform a dimension reduction if required
         if dimension_reduction:
 


### PR DESCRIPTION
Previously, when no solution, G was full of NANs and PEPit raised an annoying error when computing its eigenvalues.
Here, we stop the computation as soon as G is not a number anymore and return a more explicit Exception message.