### PR TITLE
Implement OC-Halpern & OS-PPM from Park & Ryu 2022

### DIFF
--- a/PEPit/examples/fixed_point_problems/__init__.py
+++ b/PEPit/examples/fixed_point_problems/__init__.py
@@ -1,8 +1,9 @@
 from .halpern_iteration import wc_halpern_iteration
 from .krasnoselskii_mann_constant_step_sizes import wc_krasnoselskii_mann_constant_step_sizes
 from .krasnoselskii_mann_increasing_step_sizes import wc_krasnoselskii_mann_increasing_step_sizes
-
+from .optimal_contractive_halpern_iteration import wc_optimal_contractive_halpern_iteration
 __all__ = ['halpern_iteration', 'wc_halpern_iteration',
            'krasnoselskii_mann_constant_step_sizes', 'wc_krasnoselskii_mann_constant_step_sizes',
            'krasnoselskii_mann_increasing_step_sizes', 'wc_krasnoselskii_mann_increasing_step_sizes',
+           'optimal_contractive_halpern_iteration', 'wc_optimal_contractive_halpern_iteration'
            ]

--- a/PEPit/examples/fixed_point_problems/optimal_contractive_halpern_iteration.py
+++ b/PEPit/examples/fixed_point_problems/optimal_contractive_halpern_iteration.py
@@ -1,0 +1,112 @@
+from PEPit import PEP
+from PEPit.operators import LipschitzOperator
+
+def wc_optimal_contractive_halpern_iteration(n, gamma, verbose=1):
+    """
+    Consider the fixed point problem
+
+    .. math:: \\mathrm{Find}\\, x:\\, x = Ax,
+
+    where :math:`A` is a :math:`1/\gamma`-contractive operator, i.e. a :math:`L`-Lipschitz operator with :math:`L=1/\gamma`.
+
+    This code computes a worst-case guarantee for the **Optimal Contractive Halpern Iteration**.
+    That is, it computes the smallest possible :math:`\\tau(n, \\gamma)` such that the guarantee
+
+    .. math:: \\|x_n - Ax_n\\|^2 \\leqslant \\tau(n, \\gamma) \\|x_0 - x_\\star\\|^2
+
+    is valid, where :math:`x_n` is the output of the **Optimal Contractive Halpern iteration**,
+    and :math:`x_\\star` is the fixed point of :math:`A`. In short, for a given value of :math:`n, \\gamma`,
+    :math:`\\tau(n, \\gamma)` is computed as the worst-case value of
+    :math:`\\|x_n - Ax_n\\|^2` when :math:`\\|x_0 - x_\\star\\|^2 \\leqslant 1`.
+
+    **Algorithm**: The Optimal Contractive Halpern iteration can be written as
+
+        .. math:: x_{t+1} = \\left(1 - \\frac{1}{\\varphi_{t+1}} \\right) Ax_t + \\frac{1}{\\varphi_{t+1}} x_0.
+
+    where :math:`\\varphi_k = \sum_{i=0}^k \gamma^{2i}` and :math:`x_0` is a starting point.
+
+    **Theoretical guarantee**: A **tight** worst-case guarantee for the Optimal Contractive Halpern iteration can be found in [1, Corollary 3.3, Theorem 4.1]:
+
+        .. math:: \\|x_n - Ax_n\\|^2 \\leqslant \\left(1 + \\frac{1}{\\gamma}\\right)^2 \\left( \\frac{1}{\\sum_{k=0}^n \\gamma^k} \\right)^2 \\|x_0 - x_\\star\\|^2.
+
+    **References**: The detailed approach and tight bound are available in [1].
+
+    `[1] J. Park, E. Ryu (2022). Exact Optimal Accelerated Complexity for Fixed-Point Iterations. In 39th International Conference on Machine Learning (ICML).
+    <https://proceedings.mlr.press/v162/park22c/park22c.pdf>`_
+
+    Args:
+        n (int): number of iterations.
+        gamma (float): :math:`\\gamma \ge 1`. :math:`A` will be :math:`1/\\gamma`-contractive.
+        verbose (int): Level of information details to print.
+                        
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
+
+    Returns:
+        pepit_tau (float): worst-case value
+        theoretical_tau (float): theoretical value
+
+    Example:
+        >>> pepit_tau, theoretical_tau = wc_optimal_contractive_halpern_iteration(n=10, gamma=1.1, verbose=1)
+        (PEPit) Setting up the problem: size of the main PSD matrix: 13x13
+        (PEPit) Setting up the problem: performance measure is minimum of 1 element(s)
+        (PEPit) Setting up the problem: initial conditions and general constraints (1 constraint(s) added)
+        (PEPit) Setting up the problem: interpolation conditions for 1 function(s)
+                function 1 : 132 constraint(s) added
+        (PEPit) Setting up the problem: 0 lmi constraint(s) added
+        (PEPit) Compiling SDP
+        (PEPit) Calling SDP solver
+        (PEPit) Solver status: optimal (solver: SCS); optimal value: 0.010613019546783495
+        *** Example file: worst-case performance of Optimal Contractive Halpern Iterations ***
+            PEPit guarantee:        ||xN - AxN||^2 <= 0.010613 ||x0 - x_*||^2
+            Theoretical guarantee:  ||xN - AxN||^2 <= 0.0106132 ||x0 - x_*||^2
+
+    """
+
+    # Instantiate PEP
+    problem = PEP()
+
+    # Declare a non expansive operator
+    A = problem.declare_function(LipschitzOperator, L=1/gamma)
+
+    # Start by defining its unique optimal point xs = x_*
+    xs, _, _ = A.fixed_point()
+
+    # Then define the starting point x0 of the algorithm
+    x0 = problem.set_initial_point()
+
+    # Set the initial constraint that is the difference between x0 and xs
+    problem.set_initial_condition((x0 - xs) ** 2 <= 1)
+
+    # Run n steps of Optimal Contractive Halpern Iterations
+    x = x0
+    for i in range(n):
+        phi = (gamma ** (2 * i + 4) - 1) / (gamma ** 2 - 1)
+        x = 1 / phi * x0 + (1 - 1 / phi) * A.gradient(x)
+
+    # Set the performance metric to distance between xN and AxN
+    problem.set_performance_metric((x - A.gradient(x)) ** 2)
+
+    # Solve the PEP
+    pepit_verbose = max(verbose, 0)
+    pepit_tau = problem.solve(verbose=pepit_verbose)
+
+    # Compute theoretical guarantee (for comparison)
+    theoretical_tau = (1 + 1 / gamma) ** 2 * ((gamma - 1) / (gamma ** (n + 1) - 1)) ** 2
+
+    # Print conclusion if required
+    if verbose != -1:
+        print('*** Example file: worst-case performance of Optimal Contractive Halpern Iterations ***')
+        print('\tPEPit guarantee:\t ||xN - AxN||^2 <= {:.6} ||x0 - x_*||^2'.format(pepit_tau))
+        print('\tTheoretical guarantee:\t ||xN - AxN||^2 <= {:.6} ||x0 - x_*||^2'.format(theoretical_tau))
+
+    # Return the worst-case guarantee of the evaluated method (and the reference theoretical value)
+    return pepit_tau, theoretical_tau
+
+
+if __name__ == "__main__":
+
+    pepit_tau, theoretical_tau = wc_optimal_contractive_halpern_iteration(n=10, gamma=1.1, verbose=1)
+    

--- a/PEPit/examples/monotone_inclusions/__init__.py
+++ b/PEPit/examples/monotone_inclusions/__init__.py
@@ -2,9 +2,11 @@ from .accelerated_proximal_point import wc_accelerated_proximal_point
 from .douglas_rachford_splitting import wc_douglas_rachford_splitting
 from .proximal_point import wc_proximal_point
 from .three_operator_splitting import wc_three_operator_splitting
+from .optimal_strongly_monotone_proximal_point import wc_optimal_strongly_monotone_proximal_point
 
 __all__ = ['accelerated_proximal_point', 'wc_accelerated_proximal_point',
            'douglas_rachford_splitting', 'wc_douglas_rachford_splitting',
            'proximal_point.py', 'wc_proximal_point',
            'three_operator_splitting', 'wc_three_operator_splitting',
+           'optimal_strongly_monotone_proximal_point', 'wc_optimal_strongly_monotone_proximal_point'
            ]

--- a/PEPit/examples/monotone_inclusions/optimal_strongly_monotone_proximal_point.py
+++ b/PEPit/examples/monotone_inclusions/optimal_strongly_monotone_proximal_point.py
@@ -1,0 +1,134 @@
+from PEPit import PEP
+from PEPit.operators import StronglyMonotoneOperator
+from PEPit.primitive_steps import proximal_step
+
+def phi(mu, idx):
+    if idx == -1:
+        return 0 
+    return ((1 + 2 * mu) ** (2 * idx + 2) - 1) / ((1 + 2 * mu) ** 2 - 1)
+
+def wc_optimal_strongly_monotone_proximal_point(n, mu, verbose=1):
+    """
+    Consider the monotone inclusion problem
+
+    .. math:: \\mathrm{Find}\\, x:\\, 0\\in Ax,
+
+    where :math:`A` is maximally :math:`\\mu`-strongly monotone. 
+    We denote by :math:`J_{A}` the resolvent of :math:`A`.
+
+    For any :math:`x` such that :math:`x = J_{A} y` for some :math:`y`, define the resolvent residual :math:`\\tilde{A}x = y - J_{A}y \\in Ax`.
+
+    This code computes a worst-case guarantee for the **Optimal Strongly-monotone Proximal Point Method** (OS-PPM). 
+    That is, it computes the smallest possible :math:`\\tau(n, \\mu)` such that the guarantee 
+
+    .. math:: \\|\\tilde{A}x_n\\|^2 \\leqslant \\tau(n, \\mu) \\|x_0 - x_\\star\\|^2,
+
+    is valid, where :math:`x_n` is the output of the **Optimal Strongly-monotone Proximal Point Method**,
+    and :math:`x_\\star` is a zero of :math:`A`. In short, for a given value of :math:`n, \\mu`,
+    :math:`\\tau(n, \\mu)` is computed as the worst-case value of
+    :math:`\\|\\tilde{A}x_n\\|^2` when :math:`\\|x_0 - x_\\star\\|^2 \\leqslant 1`.
+
+    **Algorithm**: The Optimal Strongly-monotone Proximal Point Method can be written as
+
+        .. math::
+            :nowrap:
+
+            \\begin{eqnarray}
+                x_{t+1} & = & J_{A} y_t,\\\\
+                y_{t+1} & = & x_{t+1} + \\frac{\\varphi_{t} - 1}{\\varphi_{t+1}} (x_{t+1} - x_t) - \\frac{2 \\mu \\varphi_{t}}{\\varphi_{t+1}} (y_t - x_{t+1}) \\\\
+                         &  & + \\frac{(1+2\\mu) \\varphi_{t-1}}{\\varphi_{t+1}} (y_{t-1} - x_t). 
+            \\end{eqnarray}
+
+    where :math:`\\varphi_k = \sum_{i=0}^k (1+2\\mu)^{2i}` with :math:`\\varphi_{-1}=0` and :math:`x_0 = y_0 = y_{-1}` is a starting point. 
+
+    This method is equivalent to the Optimal Contractive Halpern iteration.
+
+    **Theoretical guarantee**: A **tight** worst-case guarantee for the Optimal Strongly-monotone Proximal Point Method can be found in [1, Theorem 3.2, Corollary 4.2]:
+
+        .. math:: \\|\\tilde{A}x_n\\|^2 \\leqslant \\left( \\frac{1}{\sum_{k=0}^{N-1} (1+2\\mu)^k} \\right)^2 \\|x_0 - x_\\star\\|^2.
+
+    **References**: The detailed approach and tight bound are available in [1].
+
+    `[1] J. Park, E. Ryu (2022). Exact Optimal Accelerated Complexity for Fixed-Point Iterations. In 39th International Conference on Machine Learning (ICML).
+    <https://proceedings.mlr.press/v162/park22c/park22c.pdf>`_
+
+    Args:
+        n (int): number of iterations.
+        mu (float): :math:`\\mu \ge 0`. :math:`A` will be maximal :math:`\\mu`-strongly monotone.
+        verbose (int): Level of information details to print.
+                        
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
+
+    Returns:
+        pepit_tau (float): worst-case value.
+        theoretical_tau (float): theoretical value.
+
+    Example:
+        >>> pepit_tau, theoretical_tau  = wc_optimal_strongly_monotone_proximal_point(n=10, mu=0.05, verbose=1)
+        (PEPit) Setting up the problem: size of the main PSD matrix: 12x12
+        (PEPit) Setting up the problem: performance measure is minimum of 1 element(s)
+        (PEPit) Setting up the problem: initial conditions and general constraints (1 constraint(s) added)
+        (PEPit) Setting up the problem: interpolation conditions for 1 function(s)
+                function 1 : 110 constraint(s) added
+        (PEPit) Setting up the problem: 0 lmi constraint(s) added
+        (PEPit) Compiling SDP
+        (PEPit) Calling SDP solver
+        (PEPit) Solver status: optimal (solver: SCS); optimal value: 0.003936787408353186
+        (PEPit) Postprocessing: solver's output is not entirely feasible (smallest eigenvalue of the Gram matrix is: -2.67e-07 < 0).
+        Small deviation from 0 may simply be due to numerical error. Big ones should be deeply investigated.
+        In any case, from now the provided values of parameters are based on the projection of the Gram matrix onto the cone of symmetric semi-definite matrix.
+        *** Example file: worst-case performance of Optimal Strongly-monotone Proximal Point Method ***
+            PEPit guarantee:        ||AxN||^2 <= 0.00393679 ||x0 - x_*||^2
+            Theoretical guarantee:  ||AxN||^2 <= 0.00393698 ||x0 - x_*||^2
+
+    """
+
+    # Instantiate PEP
+    problem = PEP()
+
+    # Declare a monotone operator
+    A = problem.declare_function(StronglyMonotoneOperator, mu=mu)
+
+    # Start by defining the zero point xs
+    xs = A.stationary_point()
+
+    # Then define the starting point x0 of the algorithm
+    x0 = problem.set_initial_point()
+
+    # Set the initial constraint that is the difference between x0 and xs
+    problem.set_initial_condition((x0 - xs) ** 2 <= 1)
+
+    # Run n steps of Optimal Strongly-monotone Proximal Point Method
+    x, y, y_prv = x0, x0, x0
+    for i in range(n):
+        x_nxt, _, _ = proximal_step(y, A, 1)
+        y_nxt = x_nxt + (phi(mu, i) - 1) / phi(mu, i + 1) * (x_nxt - x) - 2 * mu * phi(mu, i) / phi(mu, i + 1) * (y - x_nxt) + (1 + 2 * mu) * phi(mu, i - 1) / phi(mu, i + 1) * (y_prv - x)
+        x, y_prv, y = x_nxt, y, y_nxt
+
+    # Set the performance metric to length of \tilde{A}xN
+    problem.set_performance_metric((y_prv - x) ** 2)
+
+    # Solve the PEP
+    pepit_verbose = max(verbose, 0)
+    pepit_tau = problem.solve(verbose=pepit_verbose)
+
+    # Compute theoretical guarantee (for comparison)
+    theoretical_tau = (2 * mu / ((1 + 2 * mu) ** n - 1)) ** 2
+
+    # Print conclusion if required
+    if verbose != -1:
+        print('*** Example file: worst-case performance of Optimal Strongly-monotone Proximal Point Method ***')
+        print('\tPEPit guarantee:\t ||AxN||^2 <= {:.6} ||x0 - x_*||^2'.format(pepit_tau))
+        print('\tTheoretical guarantee:\t ||AxN||^2 <= {:.6} ||x0 - x_*||^2'.format(theoretical_tau))
+
+    # Return the worst-case guarantee of the evaluated method (and the reference theoretical value)
+    return pepit_tau, theoretical_tau
+
+
+if __name__ == "__main__":
+
+    pepit_tau, theoretical_tau = wc_optimal_strongly_monotone_proximal_point(n=10, mu=0.05, verbose=1)
+    

--- a/docs/source/examples/e.rst
+++ b/docs/source/examples/e.rst
@@ -24,3 +24,8 @@ Douglas Rachford Splitting
 Three operator splitting
 ------------------------
 .. autofunction:: PEPit.examples.monotone_inclusions.wc_three_operator_splitting
+
+
+Optimal Strongly-monotone Proximal Point
+----------------------------------------
+.. autofunction:: PEPit.examples.monotone_inclusions.wc_optimal_strongly_monotone_proximal_point

--- a/docs/source/examples/f.rst
+++ b/docs/source/examples/f.rst
@@ -19,3 +19,8 @@ Krasnoselskii Mann with constant step=sizes
 Krasnoselskii Mann with increasing step=sizes
 ---------------------------------------------
 .. autofunction:: PEPit.examples.fixed_point_problems.wc_krasnoselskii_mann_increasing_step_sizes
+
+
+Optimal Contractive Halpern iteration
+---------------------------------------------
+.. autofunction:: PEPit.examples.fixed_point_problems.wc_optimal_contractive_halpern_iteration


### PR DESCRIPTION
This PR implements two methods, OC-Halpern & OS-PPM, from Park & Ryu's ICML 2022 paper https://proceedings.mlr.press/v162/park22c.html.