### PR TITLE
Fix/typos in doc

### DIFF
--- a/PEPit/examples/stochastic_and_randomized_convex_minimization/sgd_overparametrized.py
+++ b/PEPit/examples/stochastic_and_randomized_convex_minimization/sgd_overparametrized.py
@@ -100,8 +100,8 @@ def wc_sgd_overparametrized(L, mu, gamma, n, verbose=1):
         (PEPit) Calling SDP solver
         (PEPit) Solver status: optimal (solver: SCS); optimal value: 0.8099999999798264
         *** Example file: worst-case performance of stochastic gradient descent with fixed step-size and with zero variance at the optimal point ***
-                PEPit guarantee:         E[||x_1 - x_*||^2] <= 0.81
-                Theoretical guarantee:   E[||x_1 - x_*||^2] <= 0.81
+                PEPit guarantee:         E[||x_1 - x_*||^2] <= 0.81 ||x_0 - x_*||^2
+                Theoretical guarantee:   E[||x_1 - x_*||^2] <= 0.81 ||x_0 - x_*||^2
 
     """
 
@@ -142,8 +142,8 @@ def wc_sgd_overparametrized(L, mu, gamma, n, verbose=1):
     if verbose != -1:
         print('*** Example file: worst-case performance of stochastic gradient descent'
               ' with fixed step-size and with zero variance at the optimal point ***')
-        print('\tPEPit guarantee:\t E[||x_1 - x_*||^2] <= {:.6}'.format(pepit_tau))
-        print('\tTheoretical guarantee:\t E[||x_1 - x_*||^2] <= {:.6}'.format(theoretical_tau))
+        print('\tPEPit guarantee:\t E[||x_1 - x_*||^2] <= {:.6} ||x_0 - x_*||^2'.format(pepit_tau))
+        print('\tTheoretical guarantee:\t E[||x_1 - x_*||^2] <= {:.6} ||x_0 - x_*||^2'.format(theoretical_tau))
 
     # Return the worst-case guarantee of the evaluated method (and the reference theoretical value)
     return pepit_tau, theoretical_tau

--- a/tests/additional_complexified_examples_tests/gradient_exact_line_search.py
+++ b/tests/additional_complexified_examples_tests/gradient_exact_line_search.py
@@ -17,11 +17,12 @@ def wc_gradient_exact_line_search_complexified(L, mu, n, verbose=1):
         mu (float): the strong convexity parameter.
         n (int): number of iterations.
         verbose (int): Level of information details to print.
-                       -1: No verbose at all.
-                       0: This example's output.
-                       1: This example's output + PEPit information.
-                       2: This example's output + PEPit information + CVXPY details.
-    
+
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
+
     Returns:
         pepit_tau (float): worst-case value
         theoretical_tau (float): theoretical value

--- a/tests/additional_complexified_examples_tests/inexact_gradient_exact_line_search.py
+++ b/tests/additional_complexified_examples_tests/inexact_gradient_exact_line_search.py
@@ -18,10 +18,11 @@ def wc_inexact_gradient_exact_line_search_complexified(L, mu, epsilon, n, verbos
         epsilon (float): level of inaccuracy.
         n (int): number of iterations.
         verbose (int): Level of information details to print.
-                       -1: No verbose at all.
-                       0: This example's output.
-                       1: This example's output + PEPit information.
-                       2: This example's output + PEPit information + CVXPY details.
+
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
 
     Returns:
         pepit_tau (float): worst-case value

--- a/tests/additional_complexified_examples_tests/inexact_gradient_exact_line_search2.py
+++ b/tests/additional_complexified_examples_tests/inexact_gradient_exact_line_search2.py
@@ -18,10 +18,11 @@ def wc_inexact_gradient_exact_line_search_complexified2(L, mu, epsilon, n, verbo
         epsilon (float): level of inaccuracy.
         n (int): number of iterations.
         verbose (int): Level of information details to print.
-                       -1: No verbose at all.
-                       0: This example's output.
-                       1: This example's output + PEPit information.
-                       2: This example's output + PEPit information + CVXPY details.
+
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
 
     Returns:
         pepit_tau (float): worst-case value

--- a/tests/additional_complexified_examples_tests/proximal_gradient.py
+++ b/tests/additional_complexified_examples_tests/proximal_gradient.py
@@ -31,10 +31,11 @@ def wc_proximal_gradient_complexified(L, mu, gamma, n, verbose=1):
         gamma (float): the step size.
         n (int): number of iterations.
         verbose (int): Level of information details to print.
-                       -1: No verbose at all.
-                       0: This example's output.
-                       1: This example's output + PEPit information.
-                       2: This example's output + PEPit information + CVXPY details.
+
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
 
     Returns:
         pepit_tau (float): worst-case value

--- a/tests/additional_complexified_examples_tests/proximal_point.py
+++ b/tests/additional_complexified_examples_tests/proximal_point.py
@@ -18,10 +18,11 @@ def wc_proximal_point_complexified(gamma, n, verbose=1):
         gamma (float): the step size parameter.
         n (int): number of iterations.
         verbose (int): Level of information details to print.
-                       -1: No verbose at all.
-                       0: This example's output.
-                       1: This example's output + PEPit information.
-                       2: This example's output + PEPit information + CVXPY details.
+
+                        - -1: No verbose at all.
+                        - 0: This example's output.
+                        - 1: This example's output + PEPit information.
+                        - 2: This example's output + PEPit information + CVXPY details.
 
     Returns:
         tuple: worst_case value, theoretical value


### PR DESCRIPTION
Just a few typos in docstrings and print.