### PR TITLE
Fix/constraints on composite functions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 
   push:
     branches:
-      - 'master' 
+      - 'master'
       - 'develop'
   create:
     branches:

--- a/PEPit/function.py
+++ b/PEPit/function.py
@@ -31,6 +31,9 @@ class Function(object):
         list_of_stationary_points (list): The sublist of `self.list_of_points` of
                                           stationary points (characterized by some subgradient=0).
         list_of_constraints (list): The list of :class:`Constraint` objects associated with this :class:`Function`.
+        list_of_psd (list): The list of :class:`PSDMatrix` objects associated with this :class:`Function`.
+        list_of_class_constraints (list): The list of class interpolation :class:`Constraint` objects.
+        list_of_class_psd (list): The list of :class:`PSDMatrix` objects associated associated with class interpolation constraints.
         counter (int): counts the number of **leaf** :class:`Function` objects.
 
     Note:
@@ -51,6 +54,7 @@ class Function(object):
     # It counts the number of functions defined from scratch.
     # The others are linear combination of those functions.
     counter = 0
+    list_of_functions = list()
 
     def __init__(self,
                  is_leaf=True,
@@ -89,6 +93,7 @@ class Function(object):
         # Store inputs
         self._is_leaf = is_leaf
         self.reuse_gradient = reuse_gradient
+        Function.list_of_functions.append(self)
 
         # If leaf function, the decomposition is updated,
         # the object counter is set
@@ -110,6 +115,8 @@ class Function(object):
         self.list_of_points = list()
         self.list_of_constraints = list()
         self.list_of_psd = list()
+        self.list_of_class_constraints = list()
+        self.list_of_class_psd = list()
 
     def get_is_leaf(self):
         """

--- a/PEPit/functions/convex_function.py
+++ b/PEPit/functions/convex_function.py
@@ -53,4 +53,4 @@ class ConvexFunction(Function):
                 if point_i != point_j:
 
                     # Interpolation conditions of convex functions class
-                    self.add_constraint(fi - fj >= gj * (xi - xj))
+                    self.list_of_class_constraints.append(fi - fj >= gj * (xi - xj))

--- a/PEPit/functions/convex_indicator.py
+++ b/PEPit/functions/convex_indicator.py
@@ -67,9 +67,9 @@ class ConvexIndicatorFunction(Function):
                 xj, gj, fj = point_j
 
                 if point_i == point_j:
-                    self.add_constraint(fi == 0)
+                    self.list_of_class_constraints.append(fi == 0)
 
                 else:
-                    self.add_constraint(gi * (xj - xi) <= 0)
+                    self.list_of_class_constraints.append(gi * (xj - xi) <= 0)
                     if self.D != np.inf:
-                        self.add_constraint((xi - xj) ** 2 <= self.D ** 2)
+                        self.list_of_class_constraints.append((xi - xj) ** 2 <= self.D ** 2)

--- a/PEPit/functions/convex_lipschitz_function.py
+++ b/PEPit/functions/convex_lipschitz_function.py
@@ -62,7 +62,7 @@ class ConvexLipschitzFunction(Function):
             xi, gi, fi = point_i
 
             # Lipschitz condition on the function (bounded gradient)
-            self.add_constraint(gi**2 <= self.M**2)
+            self.list_of_class_constraints.append(gi**2 <= self.M**2)
 
             for point_j in self.list_of_points:
 
@@ -71,4 +71,4 @@ class ConvexLipschitzFunction(Function):
                 if point_i != point_j:
 
                     # Interpolation conditions of convex functions class
-                    self.add_constraint(fi - fj >= gj * (xi - xj))
+                    self.list_of_class_constraints.append(fi - fj >= gj * (xi - xj))

--- a/PEPit/functions/convex_qg_function.py
+++ b/PEPit/functions/convex_qg_function.py
@@ -68,7 +68,7 @@ class ConvexQGFunction(Function):
 
                 if point_i != point_j:
                     # Interpolation conditions of convex functions class
-                    self.add_constraint(fi - fj >= gj * (xi - xj) + 1 / (2 * self.L) * gj ** 2)
+                    self.list_of_class_constraints.append(fi - fj >= gj * (xi - xj) + 1 / (2 * self.L) * gj ** 2)
 
         for i, point_i in enumerate(self.list_of_points):
 
@@ -80,4 +80,4 @@ class ConvexQGFunction(Function):
 
                 if i != j:
                     # Interpolation conditions of convex functions class
-                    self.add_constraint(fi - fj >= gj * (xi - xj))
+                    self.list_of_class_constraints.append(fi - fj >= gj * (xi - xj))

--- a/PEPit/functions/convex_support_function.py
+++ b/PEPit/functions/convex_support_function.py
@@ -67,9 +67,9 @@ class ConvexSupportFunction(Function):
                 xj, gj, fj = point_j
 
                 if point_i == point_j:
-                    self.add_constraint(gi * xi - fi == 0)
+                    self.list_of_class_constraints.append(gi * xi - fi == 0)
                     if self.M != np.inf:
-                        self.add_constraint(gi ** 2 <= self.M ** 2)
+                        self.list_of_class_constraints.append(gi ** 2 <= self.M ** 2)
 
                 else:
-                    self.add_constraint(xj * (gi - gj) <= 0)
+                    self.list_of_class_constraints.append(xj * (gi - gj) <= 0)

--- a/PEPit/functions/rsi_eb.py
+++ b/PEPit/functions/rsi_eb.py
@@ -73,6 +73,6 @@ class RsiEbFunction(Function):
 
                 if (xi != xj) | (gi != gj):
                     # Interpolation conditions of RSI function class
-                    self.add_constraint((gi - gj) * (xi - xj) - self.mu * (xi - xj)**2 >= 0)
+                    self.list_of_class_constraints.append((gi - gj) * (xi - xj) - self.mu * (xi - xj)**2 >= 0)
                     # Interpolation conditions of EB function class
-                    self.add_constraint((gi - gj)**2 - self.L**2 * (xi - xj)**2 <= 0)
+                    self.list_of_class_constraints.append((gi - gj)**2 - self.L**2 * (xi - xj)**2 <= 0)

--- a/PEPit/functions/smooth_function.py
+++ b/PEPit/functions/smooth_function.py
@@ -75,7 +75,7 @@ class SmoothFunction(Function):
                 if point_i != point_j:
 
                     # Interpolation conditions of smooth functions class
-                    self.add_constraint(fi - fj
+                    self.list_of_class_constraints.append(fi - fj
                                         - self.L/4 * (xi - xj)**2
                                         - 1/2 * (gi + gj) * (xi - xj)
                                         + 1/(4 * self.L) * (gi - gj)**2

--- a/PEPit/functions/smooth_strongly_convex_function.py
+++ b/PEPit/functions/smooth_strongly_convex_function.py
@@ -80,7 +80,7 @@ class SmoothStronglyConvexFunction(Function):
                 if point_i != point_j:
 
                     # Interpolation conditions of smooth strongly convex functions class
-                    self.add_constraint(fi - fj >=
+                    self.list_of_class_constraints.append(fi - fj >=
                                         gj * (xi - xj)
                                         + 1/(2*self.L) * (gi - gj) ** 2
                                         + self.mu / (2 * (1 - self.mu / self.L)) * (xi - xj - 1/self.L * (gi - gj))**2)

--- a/PEPit/functions/strongly_convex.py
+++ b/PEPit/functions/strongly_convex.py
@@ -68,6 +68,6 @@ class StronglyConvexFunction(Function):
                 if point_i != point_j:
 
                     # Interpolation conditions of smooth strongly convex functions class
-                    self.add_constraint(fi - fj >=
+                    self.list_of_class_constraints.append(fi - fj >=
                                         gj * (xi - xj)
                                         + self.mu / 2 * (xi - xj) ** 2)

--- a/PEPit/operators/cocoercive.py
+++ b/PEPit/operators/cocoercive.py
@@ -79,4 +79,4 @@ class CocoerciveOperator(Function):
 
                 if (xi != xj) | (gi != gj):
                     # Interpolation conditions of cocoercive operator class
-                    self.add_constraint((gi - gj) * (xi - xj) - self.beta * (gi - gj) ** 2 >= 0)
+                    self.list_of_class_constraints.append((gi - gj) * (xi - xj) - self.beta * (gi - gj) ** 2 >= 0)

--- a/PEPit/operators/lipschitz.py
+++ b/PEPit/operators/lipschitz.py
@@ -95,4 +95,4 @@ class LipschitzOperator(Function):
 
                 if (xi != xj) | (gi != gj):
                     # Interpolation conditions of Lipschitz operator class
-                    self.add_constraint((gi - gj) ** 2 - self.L ** 2 * (xi - xj) ** 2 <= 0)
+                    self.list_of_class_constraints.append((gi - gj) ** 2 - self.L ** 2 * (xi - xj) ** 2 <= 0)

--- a/PEPit/operators/lipschitz_strongly_monotone.py
+++ b/PEPit/operators/lipschitz_strongly_monotone.py
@@ -90,6 +90,6 @@ class LipschitzStronglyMonotoneOperator(Function):
 
                 if (xi != xj) | (gi != gj):
                     # Interpolation conditions of strongly monotone operator class
-                    self.add_constraint((gi - gj) * (xi - xj) - self.mu * (xi - xj)**2 >= 0)
+                    self.list_of_class_constraints.append((gi - gj) * (xi - xj) - self.mu * (xi - xj)**2 >= 0)
                     # Interpolation conditions of Lipschitz operator class
-                    self.add_constraint((gi - gj)**2 - self.L**2 * (xi - xj)**2 <= 0)
+                    self.list_of_class_constraints.append((gi - gj)**2 - self.L**2 * (xi - xj)**2 <= 0)

--- a/PEPit/operators/monotone.py
+++ b/PEPit/operators/monotone.py
@@ -59,4 +59,4 @@ class MonotoneOperator(Function):
 
                 if (xi != xj) | (gi != gj):
                     # Interpolation conditions of monotone operator class
-                    self.add_constraint((gi - gj) * (xi - xj) >= 0)
+                    self.list_of_class_constraints.append((gi - gj) * (xi - xj) >= 0)

--- a/PEPit/operators/strongly_monotone.py
+++ b/PEPit/operators/strongly_monotone.py
@@ -72,4 +72,4 @@ class StronglyMonotoneOperator(Function):
 
                 if (xi != xj) | (gi != gj):
                     # Interpolation conditions of strongly monotone operator class
-                    self.add_constraint((gi - gj) * (xi - xj) - self.mu * (xi - xj) ** 2 >= 0)
+                    self.list_of_class_constraints.append((gi - gj) * (xi - xj) - self.mu * (xi - xj) ** 2 >= 0)

--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -443,8 +443,7 @@ class PEP(object):
                           'lmi constraint(s) ...')
 
                 for psd_counter, psd_matrix in enumerate(function.list_of_psd):
-                    cvxpy_constraints_list += self.send_lmi_constraint_to_cvxpy(psd_counter, psd_matrix, F, G,
-                                                                                verbose)
+                    cvxpy_constraints_list += self.send_lmi_constraint_to_cvxpy(psd_counter, psd_matrix, F, G, verbose)
 
                 if verbose:
                     print('\t\t function', function_counter, ':', len(function.list_of_psd),

--- a/docs/source/whatsnew/0.2.1.rst
+++ b/docs/source/whatsnew/0.2.1.rst
@@ -7,3 +7,17 @@ What's new in PEPit 0.2.1
 
 - Fix: Points that were not associated with Functions could be not evaluable after solving the PEP (See Issue `#74 <https://github.com/PerformanceEstimation/PEPit/issues/74>`_).
        This has been fixed in PR `#75 <https://github.com/PerformanceEstimation/PEPit/pull/75>`_.
+
+- Fix: Constraints on a function defined a linear combination of other functions were not taken into consideration.
+       This has been fixed in PR `#80 <https://github.com/PerformanceEstimation/PEPit/pull/80>`_.
+
+- The attributes `list_of_constraints` and `list_of_psd` of :class:`Function` objects have respectively been splitted into
+`list_of_constraints` and `list_of_class_constraints` (the latter containing the interpolation constraints of the class of functions),
+and into `list_of_psd` and `list_of_class_psd` (the latter containing the lmi interpolation constraints of the class of functions).
+The 2 lists containing the interpolation constraints are filled when the PEP solver is called.
+
+- The attributes `list_of_functions` and `list_of_points` of the :class:`PEP` objects are not used anymore in the pipeline.
+They still contains the same elements as in previous version of PEPit and can still be called for now.
+However, they will be removed in a future version of PEPit, therefore we discourage from using them.
+The full list of functions as well as the full list of points can respectively be obtained in
+`Function.list_of_functions` and `Point.list_of_points`.

--- a/tests/additional_complexified_examples_tests/gradient_exact_line_search.py
+++ b/tests/additional_complexified_examples_tests/gradient_exact_line_search.py
@@ -52,7 +52,9 @@ def wc_gradient_exact_line_search_complexified(L, mu, n, verbose=1):
     problem = PEP()
 
     # Declare a smooth strongly convex function
-    func = problem.declare_function(SmoothStronglyConvexFunction, mu=mu, L=L)
+    f1 = problem.declare_function(SmoothStronglyConvexFunction, mu=mu, L=L)
+    f2 = problem.declare_function(SmoothStronglyConvexFunction, mu=mu, L=L)
+    func = f1 + f2
 
     # Start by defining its unique optimal point xs = x_* and corresponding function value fs = f_*
     xs = func.stationary_point()

--- a/tests/additional_complexified_examples_tests/inexact_gradient_exact_line_search.py
+++ b/tests/additional_complexified_examples_tests/inexact_gradient_exact_line_search.py
@@ -93,7 +93,6 @@ def wc_inexact_gradient_exact_line_search_complexified(L, mu, epsilon, n, verbos
     
     # for test: attempt to evaluate a point that was not created through a pep object. 
     x.eval()
-    
 
     # Print conclusion if required
     if verbose != -1:

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -51,9 +51,9 @@ class TestConstraints(unittest.TestCase):
         for i in range(len(self.problem.list_of_constraints)):
             self.assertIsInstance(self.problem.list_of_constraints[i], Constraint)
             self.assertIsInstance(self.problem.list_of_constraints[i].expression, Expression)
-        for i in range(len(self.func.list_of_constraints)):
-            self.assertIsInstance(self.func.list_of_constraints[i], Constraint)
-            self.assertIsInstance(self.func.list_of_constraints[i].expression, Expression)
+        for i in range(len(self.func.list_of_class_constraints)):
+            self.assertIsInstance(self.func.list_of_class_constraints[i], Constraint)
+            self.assertIsInstance(self.func.list_of_class_constraints[i].expression, Expression)
 
     def test_counter(self):
 
@@ -67,14 +67,14 @@ class TestConstraints(unittest.TestCase):
             self.assertIs(self.problem.list_of_constraints[i].counter, i)
 
         # class constraints are added after initial conditions in PEP
-        for i in range(len(self.func.list_of_constraints)):
-            self.assertIs(self.func.list_of_constraints[i].counter, i + len(self.problem.list_of_constraints))
+        for i in range(len(self.func.list_of_class_constraints)):
+            self.assertIs(self.func.list_of_class_constraints[i].counter, i + len(self.problem.list_of_constraints))
 
     def test_equality_inequality(self):
 
-        for i in range(len(self.func.list_of_constraints)):
-            self.assertIsInstance(self.func.list_of_constraints[i].equality_or_inequality, str)
-            self.assertIn(self.func.list_of_constraints[i].equality_or_inequality, {'equality', 'inequality'})
+        for i in range(len(self.func.list_of_class_constraints)):
+            self.assertIsInstance(self.func.list_of_class_constraints[i].equality_or_inequality, str)
+            self.assertIn(self.func.list_of_class_constraints[i].equality_or_inequality, {'equality', 'inequality'})
 
         for i in range(len(self.problem.list_of_constraints)):
             self.assertIsInstance(self.problem.list_of_constraints[i].equality_or_inequality, str)
@@ -82,20 +82,20 @@ class TestConstraints(unittest.TestCase):
 
     def test_eval(self):
 
-        for i in range(len(self.func.list_of_constraints)):
-            self.assertIsInstance(self.func.list_of_constraints[i].eval(), float)
+        for i in range(len(self.func.list_of_class_constraints)):
+            self.assertIsInstance(self.func.list_of_class_constraints[i].eval(), float)
 
         for i in range(len(self.problem.list_of_constraints)):
             self.assertIsInstance(self.problem.list_of_constraints[i].eval(), float)
 
     def test_eval_dual(self):
 
-        for i in range(len(self.func.list_of_constraints)):
-            self.assertIsInstance(self.func.list_of_constraints[i].eval_dual(), float)
+        for i in range(len(self.func.list_of_class_constraints)):
+            self.assertIsInstance(self.func.list_of_class_constraints[i].eval_dual(), float)
 
         for i in range(len(self.problem.list_of_constraints)):
             self.assertIsInstance(self.problem.list_of_constraints[i].eval_dual(), float)
 
-        self.assertEqual(len([constraint.eval_dual() for constraint in self.func.list_of_constraints]), 2)
-        for constraint in self.func.list_of_constraints:
+        self.assertEqual(len([constraint.eval_dual() for constraint in self.func.list_of_class_constraints]), 2)
+        for constraint in self.func.list_of_class_constraints:
             self.assertAlmostEqual(constraint.eval_dual(), 1.8, places=4)

--- a/tests/test_pep.py
+++ b/tests/test_pep.py
@@ -48,10 +48,10 @@ class TestPEP(unittest.TestCase):
         self.assertEqual(len(self.problem.list_of_points), 1)
         self.assertEqual(len(self.problem.list_of_constraints), 1)
         self.assertEqual(len(self.problem.list_of_performance_metrics), 1)
-        self.assertEqual(len(self.func.list_of_constraints), 0)
+        self.assertEqual(len(self.func.list_of_class_constraints), 0)
 
         pepit_tau = self.problem.solve(verbose=0)
-        self.assertEqual(len(self.func.list_of_constraints), 2)
+        self.assertEqual(len(self.func.list_of_class_constraints), 2)
         self.assertEqual(Point.counter, 3)
         self.assertEqual(Expression.counter, 2)
         self.assertEqual(Function.counter, 1)
@@ -88,7 +88,7 @@ class TestPEP(unittest.TestCase):
             self.assertIsInstance(condition._dual_variable_value, float)
             self.assertAlmostEqual(condition._dual_variable_value, pepit_tau, delta=pepit_tau * 10 ** -3)
 
-        for constraint in self.func.list_of_constraints:
+        for constraint in self.func.list_of_class_constraints:
             self.assertIsInstance(constraint._dual_variable_value, float)
             self.assertAlmostEqual(constraint._dual_variable_value,
                                    2 * self.gamma * max(abs(1 - self.mu * self.gamma), abs(1 - self.L * self.gamma)),

--- a/tests/test_smooth_strongly_convex_functions.py
+++ b/tests/test_smooth_strongly_convex_functions.py
@@ -54,7 +54,7 @@ class TestConstraintsStronglyConvex(unittest.TestCase):
         self.assertIs(self.point1.counter, 0)
         self.assertIs(self.point2.counter, 1)
 
-        self.assertIs(len(function.list_of_constraints), 0)
+        self.assertIs(len(function.list_of_class_constraints), 0)
 
         # Add points and constraints
         function.oracle(self.point1)
@@ -62,8 +62,8 @@ class TestConstraintsStronglyConvex(unittest.TestCase):
         function.add_class_constraints()
 
         self.assertIs(len(function.list_of_points), 2)
-        self.assertIs(len(function.list_of_constraints), 2)
-        self.assertIs(function.list_of_constraints[-1].counter, 1)
+        self.assertIs(len(function.list_of_class_constraints), 2)
+        self.assertIs(function.list_of_class_constraints[-1].counter, 1)
 
     def test_add_constraints(self):
         new_function = self.compute_linear_combination()
@@ -77,14 +77,14 @@ class TestConstraintsStronglyConvex(unittest.TestCase):
         self.func2.add_class_constraints()
 
         # Count constraints
-        self.assertEqual(len(new_function.list_of_constraints), 0)
-        self.assertEqual(len(self.func1.list_of_constraints), 6)
-        self.assertEqual(len(self.func2.list_of_constraints), 6)
+        self.assertEqual(len(new_function.list_of_class_constraints), 0)
+        self.assertEqual(len(self.func1.list_of_class_constraints), 6)
+        self.assertEqual(len(self.func2.list_of_class_constraints), 6)
 
         # Test constraints type
-        for i in range(len(self.func1.list_of_constraints)):
-            self.assertIsInstance(self.func1.list_of_constraints[i], Constraint)
-            self.assertIsInstance(self.func2.list_of_constraints[i], Constraint)
+        for i in range(len(self.func1.list_of_class_constraints)):
+            self.assertIsInstance(self.func1.list_of_class_constraints[i], Constraint)
+            self.assertIsInstance(self.func2.list_of_class_constraints[i], Constraint)
 
     def test_sum_smooth_strongly_convex_functions(self):
 


### PR DESCRIPTION
- Fix: Constraints on a function defined a linear combination of other functions were not taken into consideration.

- The attributes `list_of_constraints` and `list_of_psd` of :class:`Function` objects have respectively been splitted into
`list_of_constraints` and `list_of_class_constraints` (the latter containing the interpolation constraints of the class of functions), and into `list_of_psd` and `list_of_class_psd` (the latter containing the lmi interpolation constraints of the class of functions). The 2 lists containing the interpolation constraints are filled when the PEP solver is called.

- The attributes `list_of_functions` and `list_of_points` of the :class:`PEP` objects are not used anymore in the pipeline. They still contains the same elements as in previous version of PEPit and can still be called for now. However, they will be removed in a future version of PEPit, therefore we discourage from using them. The full list of functions as well as the full list of points can respectively be obtained in `Function.list_of_functions` and `Point.list_of_points`.