### PR TITLE
polish_before_merge

### DIFF
--- a/PEPit/examples/composite_convex_minimization/improved_interior_algorithm.py
+++ b/PEPit/examples/composite_convex_minimization/improved_interior_algorithm.py
@@ -153,7 +153,7 @@ def wc_improved_interior_algorithm(L, mu, c, lam, n, wrapper="cvxpy", solver=Non
     # Solve the PEP
     pepit_verbose = max(verbose, 0)
     pepit_tau = problem.solve(wrapper=wrapper, solver=solver, verbose=pepit_verbose)
-    if problem.wrapper.solver_name.casefold() != "mosek":
+    if problem.wrapper.solver_name.casefold() != "mosek" and verbose > 0:
         print("\033[96m(PEPit) We recommend to use MOSEK solver. \033[0m")
 
     # Compute theoretical guarantee (for comparison)

--- a/PEPit/pep.py
+++ b/PEPit/pep.py
@@ -562,8 +562,9 @@ class PEP(object):
 
         # Raise explicit error when wc_value in infinite
         if wc_value is None:
-            print("\033[96m(PEPit) Problem issue: PEPit didn't find any nontrivial worst-case guarantee. "
-                  "It seems that the optimal value of your problem is unbounded.\033[0m")
+            if verbose:
+                print("\033[96m(PEPit) PEP issue: PEPit didn't find any nontrivial worst-case guarantee. "
+                      "It seems that the optimal value of your problem is unbounded.\033[0m")
 
             # Skip the following as no variable has a value
             return wc_value
@@ -807,7 +808,7 @@ class PEP(object):
             if absolute_duality_gap < 0:
                 message += " and negative"
             message += ".\n\t\tThe solver might not have converged properly.\n"\
-                       "\t\tWe recommend to use another wrapper or solver for confirmation.\033[0m"
+                       "\t\tWe recommend to use another solver for confirmation.\033[0m"
             print(message)
 
         return dual_objective

--- a/tests/test_functions_and_operators.py
+++ b/tests/test_functions_and_operators.py
@@ -90,6 +90,8 @@ class TestFunctionsAndOperators(unittest.TestCase):
         self.new_point: Point = np.dot(self.points_weights, self.all_points)
         self.new_point.set_name("combined point")
 
+        self.verbose = 0
+
     def test_is_instance(self):
 
         for function in self.all_functions_and_operators:
@@ -206,7 +208,7 @@ class TestFunctionsAndOperators(unittest.TestCase):
 
         self.pep.set_initial_condition((self.point1 - self.point2)**2 <= 1)
         self.pep.set_performance_metric((self.func7.gradient(self.point1) - self.func7.gradient(self.point2))**2)
-        self.pep.solve()
+        self.pep.solve(verbose=self.verbose)
 
         for function in self.all_functions_and_operators:
             tables_of_constraints = function.tables_of_constraints

--- a/tests/test_psd_matrix.py
+++ b/tests/test_psd_matrix.py
@@ -55,6 +55,8 @@ class TestPSDMatrix(unittest.TestCase):
         # And the dual variables are
         #     [[bound ** (-1/4)/4, - bound ** (1/4)/4], [- bound ** (1/4)/4, bound ** (3/4)/4]],
         #     [[bound ** (-1/4)/2, - 1/2], [- 1/2, bound ** (1/4)/2]].
+        
+        self.verbose = 0
 
     def test_is_instance(self):
 
@@ -106,7 +108,7 @@ class TestPSDMatrix(unittest.TestCase):
         self.assertRaises(ValueError, self.psd2.eval)
 
         # Solve the problem.
-        self.problem.solve()
+        self.problem.solve(verbose=self.verbose)
         
         # Now we can have access to the optimal values of the PSD matrices.
         optimal_psd1 = [[self.bound, self.bound ** (1/2)], [self.bound ** (1/2), 1]]
@@ -122,7 +124,7 @@ class TestPSDMatrix(unittest.TestCase):
         self.assertRaises(ValueError, self.psd2.eval_dual)
 
         # Solve the problem.
-        self.problem.solve()
+        self.problem.solve(verbose=self.verbose)
 
         # Now we can have access to the optimal dual values of the LMI constraints.
         optimal_dual_lmi1 = [[self.bound ** (-1/4)/4, - self.bound ** (1/4)/4], [- self.bound ** (1/4)/4, self.bound ** (3/4)/4]]


### PR DESCRIPTION
The feature/variable_naming PR seems very good; the one here performs some minor changes on it:

- minor changes in the PR (Verbosity changes: warnings are not printed by default)

And the following shoud be checked (Baptiste)
- for unit tests without MOSEK: it takes forever ! Also, some output by CVXPY: "UserWarning: Solution may be inaccurate. Try another solver, adjusting the solver settings, or solve with verbose=True for more information. warnings.warn("
- for "relative duality gaps" -> mb check if relevant? This might be problematic in cases where either primal or dual is zero (it is actually the case for a few examples involving Lyapunov/potential functions; e.g., PEPit/examples/continuous_time_models/gradient_flow_convex.py)
- the "solve" from PEP does not return a guarantee: it returns the value of the primal problem, not that of the dual one. It should either return the dual one (at least for all examples: if we claim "f(x)-f_*\leq XXX", XXX must be the dual value computed; one of the referee explicitly asked this, and this is, philosophically, the honest thing to do; even if it does not change much)
- there is one test not passing in it...?
- with Aymeric: please discuss & update the "list of contributors" + descriptions of the contributions in the README.md
- it seems to me that when decomposing the matrix G (for evaluating x's, etc.), the eigenvalues are not ordered (so the nonzero component in x_k's are not the first components appearing when evaluating them); possible to check/fix (issue already raised several times)
- In all smooth or Lipschitz classes of functions (and Lipschitz or cocoercive operators) have default parameters set to 1. (except BlockSmoothConvexFunction). I believe there should NOT be default parameters (default is np.Inf) ! Or at least mention it in documentation? 