### PR TITLE
Added the support of convex indicator for feasible sets bounded by a radius

### DIFF
--- a/PEPit/functions/convex_indicator.py
+++ b/PEPit/functions/convex_indicator.py
@@ -10,14 +10,15 @@ class ConvexIndicatorFunction(Function):
 
     Attributes:
         D (float): upper bound on the diameter of the feasible set, possibly set to np.inf
-
-    Convex indicator functions are characterized by a parameter `D`, hence can be instantiated as
+        R (float): upper bound on the radius of the feasible set, possibly set to np.inf
+    Convex indicator functions are characterized by a parameter `D` (or `R`), hence can be instantiated as
 
     Example:
         >>> from PEPit import PEP
         >>> from PEPit.functions import ConvexIndicatorFunction
         >>> problem = PEP()
         >>> func = problem.declare_function(function_class=ConvexIndicatorFunction, D=1)
+        >>> func = problem.declare_function(function_class=ConvexIndicatorFunction, R=1)
 
     References:
 
@@ -30,6 +31,7 @@ class ConvexIndicatorFunction(Function):
 
     def __init__(self,
                  D=np.inf,
+                 R=np.inf,
                  is_leaf=True,
                  decomposition_dict=None,
                  reuse_gradient=False,
@@ -38,6 +40,7 @@ class ConvexIndicatorFunction(Function):
 
         Args:
             D (float): Diameter of the support of self. Default value set to infinity.
+            R (float): Radius of the support of self. Default value set to infinity.
             is_leaf (bool): True if self is defined from scratch.
                             False if self is defined as linear combination of leaf.
             decomposition_dict (dict): Decomposition of self as linear combination of leaf :class:`Function` objects.
@@ -56,6 +59,7 @@ class ConvexIndicatorFunction(Function):
 
         # Store the diameter D in an attribute
         self.D = D
+        self.R = R
 
     @staticmethod
     def set_value_constraint_i(xi, gi, fi):
@@ -90,7 +94,8 @@ class ConvexIndicatorFunction(Function):
         """
         # Diameter constraint
         constraint = ((xi - xj) ** 2 <= self.D ** 2)
-
+        # Radius constraint 
+        constraint = ((xi)**2 <= self.R ** 2)
         return constraint
 
     def add_class_constraints(self):
@@ -108,7 +113,7 @@ class ConvexIndicatorFunction(Function):
                                                       constraint_name="convexity",
                                                       set_class_constraint_i_j=self.set_convexity_constraint_i_j,
                                                       )
-        if self.D != np.inf:
+        if (self.D != np.inf) or (self.R != np.inf):
             self.add_constraints_from_two_lists_of_points(list_of_points_1=self.list_of_points,
                                                           list_of_points_2=self.list_of_points,
                                                           constraint_name="diameter",


### PR DESCRIPTION
I added and documented the support of convex indicator for radiali bounded feasible sets. The way I added the support allows to add diameter and radius constraints simultaneously. I don't know if it is a good thing or not from the POV of maintainers.

Cheers,
Erwan 